### PR TITLE
Fix quaternion gimbal lock

### DIFF
--- a/quaternion.py
+++ b/quaternion.py
@@ -429,8 +429,10 @@ class QuaternionBase(object):
                               dcm[0][2] + dcm[1][1]) + phi)
         elif abs(theta + np.pi/2) < 1.0e-3:
             phi = 0.0
-            psi = np.arctan2(dcm[1][2] - dcm[0][1],
-                             dcm[0][2] + dcm[1][1] - phi)
+            psi = np.arctan2(
+                dcm[1][2] - dcm[0][1],
+                dcm[0][2] + dcm[1][1]
+            ) - phi
         else:
             phi = np.arctan2(dcm[2][1], dcm[2][2])
             psi = np.arctan2(dcm[1][0], dcm[0][0])


### PR DESCRIPTION
## Summary
- fix `_dcm_to_euler` calculation when pitch is -pi/2

## Testing
- `python -m py_compile quaternion.py`


------
https://chatgpt.com/codex/tasks/task_b_683e0a0a7dc08322805dc59ed344e37d